### PR TITLE
Fix Python style and lint issues

### DIFF
--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -1,3 +1,3 @@
-[pep8]
+[pycodestyle]
 max-line-length = 160
 exclude = yasmine/alembic/*

--- a/backend/yasmine/app/enums/xml_error.py
+++ b/backend/yasmine/app/enums/xml_error.py
@@ -51,8 +51,8 @@ class XmlErrorEnum(object):
     ERROR_251 = "Distance from station to channel must not exceed 1 km"
     ERROR_252 = "Channel epoch overlap not allowed"
     # Channel level validation
-    ERROR_301 = "Channel attribute 'code' cannot be null must match [A-Za-z0-9\*\?]{13}"
-    ERROR_302 = "Channel attribute 'location' cannot be null must match ([A-Za-z0-9\*\?\-\ ]{12})?"
+    ERROR_301 = r"Channel attribute 'code' cannot be null must match [A-Za-z0-9\*\?]{13}"
+    ERROR_302 = r"Channel attribute 'location' cannot be null must match ([A-Za-z0-9\*\?\-\ ]{12})?"
     ERROR_303 = "Channel startDate is required"
     ERROR_305 = "Channel startDate < endDate when endDate available"
     ERROR_306 = "Channel latitude is invalid"

--- a/backend/yasmine/app/handlers/base.py
+++ b/backend/yasmine/app/handlers/base.py
@@ -441,13 +441,13 @@ class FileHangler(AsyncThreadMixin, BaseHandler):
                     if filter_value.lower() not in record_value.lower():
                         return False
                 elif filter_criteria['operator'] == 'lt':
-                    if not(record_value < filter_value):
+                    if not (record_value < filter_value):
                         return False
                 elif filter_criteria['operator'] == 'gt':
-                    if not(record_value > filter_value):
+                    if not (record_value > filter_value):
                         return False
                 elif filter_criteria['operator'] == 'eq':
-                    if not(record_value == filter_value):
+                    if not (record_value == filter_value):
                         return False
         return True
 

--- a/backend/yasmine/app/handlers/xml_nrlv2.py
+++ b/backend/yasmine/app/handlers/xml_nrlv2.py
@@ -15,13 +15,13 @@ import re
 import sys
 from random import random
 
-_RE_STRIP_FILE_LINE = re.compile(r'^.+?\.py:\d+:?\s*')
-
 from yasmine.app.handlers.base import AsyncThreadMixin, BaseHandler
 from yasmine.app.helpers.nrl.nrlv2_online import Nrlv2OnlineHelper, Nrlv2OnlineError
 from yasmine.app.helpers.utils.utils import ChannelUtils
 from yasmine.app.settings import MEDIA_ROOT
 from yasmine.app.utils.response_plot import polynomial_or_polezero_response
+
+_RE_STRIP_FILE_LINE = re.compile(r'^.+?\.py:\d+:?\s*')
 
 
 def _get_nrlv2_helper(application):

--- a/backend/yasmine/app/helpers/ial/ial_channel_response_builder.py
+++ b/backend/yasmine/app/helpers/ial/ial_channel_response_builder.py
@@ -600,8 +600,14 @@ class IalChannelResponseBuilder:
                         for x in coefficients:
                             try:
                                 val = float(x) if not isinstance(x, (int, float)) else x
-                                numerator.append(FloatWithUncertaintiesAndUnit(val, lower_uncertainty=None,
-                                             upper_uncertainty=None, unit=None))
+                                numerator.append(
+                                    FloatWithUncertaintiesAndUnit(
+                                        val,
+                                        lower_uncertainty=None,
+                                        upper_uncertainty=None,
+                                        unit=None
+                                    )
+                                )
                             except (ValueError, TypeError):
                                 logger.warning("%s: FIR stage:%d skipping invalid coefficient: %s" %
                                                (fname, stage_sequence_number, x))

--- a/backend/yasmine/app/helpers/nrl/nrl_key_creator.py
+++ b/backend/yasmine/app/helpers/nrl/nrl_key_creator.py
@@ -55,6 +55,6 @@ class NrlKeyCreator:
                             'text': child[0],
                             'leaf': True
                         })
-            except:  # @IgnorePep8
+            except Exception:  # @IgnorePep8
                 pass
         return data

--- a/backend/yasmine/app/lookup/lookup_objects.py
+++ b/backend/yasmine/app/lookup/lookup_objects.py
@@ -88,5 +88,5 @@ class Utils:
     def parse_string_list(value):
         if isinstance(value, list):
             return value
-        if type(value) == str:
+        if isinstance(value, str):
             return [value]

--- a/backend/yasmine/app/run.py
+++ b/backend/yasmine/app/run.py
@@ -40,16 +40,6 @@ from datetime import datetime
 from logging.config import dictConfig
 import logging
 import os
-import warnings
-
-# ObsPy warns when response has multiple PolesZerosResponseStage (uses first).
-# NRLv2/StationXML can have multiple; behavior is correct, suppress noise.
-warnings.filterwarnings(
-    'ignore',
-    message='More than one PolesZerosResponseStage encountered',
-    category=UserWarning
-)
-
 from apscheduler.schedulers.tornado import TornadoScheduler
 from apscheduler.triggers.combining import OrTrigger
 from apscheduler.triggers.cron import CronTrigger
@@ -65,6 +55,15 @@ from yasmine.app.helpers.library_helper_factory import LibraryHelperFactory
 from yasmine.app.settings import TORNADO_SETTINGS, TORNADO_PORT, TORNADO_HOST, LOGGING_CONFIG, LOGIING_CONSOLE_CONFIG, \
     NRL_CRON, MEDIA_ROOT
 from yasmine.app.utils.facade import ProcessMixin
+import warnings
+
+# ObsPy warns when response has multiple PolesZerosResponseStage (uses first).
+# NRLv2/StationXML can have multiple; behavior is correct, suppress noise.
+warnings.filterwarnings(
+    'ignore',
+    message='More than one PolesZerosResponseStage encountered',
+    category=UserWarning
+)
 
 logger = logging.getLogger("tornado.application")
 
@@ -164,7 +163,7 @@ class Application(tornado.web.Application, ProcessMixin):
         try:
             library_helper = LibraryHelperFactory().get_helper(LibraryTypeEnum.NRL)
             library_helper.sync()
-        except:  # @IgnorePep8
+        except Exception:  # @IgnorePep8
             self.sync_nrl_started = False
 
     def sync_ial(self):
@@ -172,7 +171,7 @@ class Application(tornado.web.Application, ProcessMixin):
         try:
             library_helper = LibraryHelperFactory().get_helper(LibraryTypeEnum.AROL)
             library_helper.sync()
-        except:  # @IgnorePep8
+        except Exception:  # @IgnorePep8
             self.sync_ial_started = False
 
 

--- a/backend/yasmine/app/services/attribute_service.py
+++ b/backend/yasmine/app/services/attribute_service.py
@@ -140,7 +140,7 @@ class AttributeService(HandlerMixin, EquipmentMixin):
         for key, value in json_obj.items():
             if key == 'children':
                 for item in value:
-                    if type(item) == dict:
+                    if isinstance(item, dict):
                         self._prepare_response_json_as_xml(item, parent_node)
                     else:
                         self.response_xml_str += str(item)
@@ -157,7 +157,7 @@ class AttributeService(HandlerMixin, EquipmentMixin):
                     parent_node, attrs) + self.response_xml_str[end:]
             else:
                 self.response_xml_str += '<%s>' % key
-                if type(value) == dict:
+                if isinstance(value, dict):
                     self._prepare_response_json_as_xml(value, key)
                 else:
                     self.response_xml_str += str(value)

--- a/backend/yasmine/app/services/wizard_service.py
+++ b/backend/yasmine/app/services/wizard_service.py
@@ -35,6 +35,10 @@ from obspy import UTCDateTime
 from obspy.core.inventory import Site
 from sqlalchemy.orm import joinedload
 
+from yasmine.app.handlers.equipment import EquipmentMixin
+from yasmine.app.models import XmlNodeInstModel, XmlNodeModel, XmlNodeAttrModel, XmlNodeAttrValModel
+from yasmine.app.services.xml_service import XmlService
+from yasmine.app.utils.facade import HandlerMixin
 from yasmine.app.enums.xml_node import XmlNodeEnum, XmlNodeAttrEnum
 
 
@@ -44,10 +48,6 @@ def _to_datetime(val):
         return None
     utc = UTCDateTime(val)
     return utc.datetime
-from yasmine.app.handlers.equipment import EquipmentMixin
-from yasmine.app.models import XmlNodeInstModel, XmlNodeModel, XmlNodeAttrModel, XmlNodeAttrValModel
-from yasmine.app.services.xml_service import XmlService
-from yasmine.app.utils.facade import HandlerMixin
 
 
 class WizardService(HandlerMixin, EquipmentMixin):

--- a/backend/yasmine/app/settings.py
+++ b/backend/yasmine/app/settings.py
@@ -68,7 +68,7 @@ DATE_FORMAT_SYSTEM = '%d/%m/%Y %H:%M:%S'  # @UnusedVariable
 
 try:
     from yasmine.settings.dev import *
-except:  # @IgnorePep8
+except Exception:  # @IgnorePep8
     pass
 
 MEDIA_ROOT = os.path.join(APP_DIR, '_media')  # @UnusedVariable

--- a/backend/yasmine/app/tests/unit/attr_validation_test.py
+++ b/backend/yasmine/app/tests/unit/attr_validation_test.py
@@ -33,8 +33,11 @@
 
 import unittest
 
-from yasmine.app.utils.inv_valid import ValueRequired, ValueLength,\
-    ValueWithinRange
+from yasmine.app.utils.inv_valid import (
+    ValueRequired,
+    ValueLength,
+    ValueWithinRange,
+)
 
 
 class AttrValidationTests(unittest.TestCase):

--- a/backend/yasmine/app/utils/config.py
+++ b/backend/yasmine/app/utils/config.py
@@ -32,8 +32,11 @@
 
 
 from yasmine.app.enums.xml_node import XmlNodeEnum
-from yasmine.app.enums.configs import NetworkCfgEnum, StationCfgEnum,\
-    ChannelCfgEnum
+from yasmine.app.enums.configs import (
+    NetworkCfgEnum,
+    StationCfgEnum,
+    ChannelCfgEnum,
+)
 
 
 class ConfigDict(object):


### PR DESCRIPTION
Normalize import layout and whitespace, replace type(...) checks with isinstance, and adjust lint-related formatting/config in backend modules and tests.